### PR TITLE
Fix/configure log level with quarkus

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:WARN}
+quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:INFO}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:WARN}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,1 +1,15 @@
+# Copyright 2019-2020 Alex Stockinger
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:WARN}


### PR DESCRIPTION
The ability to set the loglevel via KAFKAPROXY_LOG_LEVEL was lost during migration to the Quarkus runtime. This PR fixes that.