### PR TITLE
Add support for multiple bootstrap brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ kafkaproxy is built to be run in a container. The released versions are availabl
 The following configuration parameters are mandatory:
 * `KAFKAPROXY_HOSTNAME`: the hostname at which the proxy can be reached from the clients.
 * `KAFKAPROXY_BASE_PORT`: the first port to be used by kafkaproxy.
-* `KAFKAPROXY_BOOTSTRAP_SERVER`: the bootstrap server via which the kafka cluster can be contacted. This is usually a load balancer in front of the kafka cluster.
+* `KAFKAPROXY_BOOTSTRAP_SERVERS`: the bootstrap server via which the kafka cluster can be contacted. This is usually a load balancer in front of the kafka cluster.
 
 For example:
 ```
@@ -29,7 +29,7 @@ docker run \
     --net host \
     -e KAFKAPROXY_HOSTNAME=localhost \
     -e KAFKAPROXY_BASE_PORT=4000 \
-    -e KAFKAPROXY_BOOTSTRAP_SERVER=kafka:9092 \
+    -e KAFKAPROXY_BOOTSTRAP_SERVERS=kafka:9092 \
     -d dajudge/kafkaproxy:0.0.3
 ``` 
 *Note:* You will have to make the proxy ports defined in your broker map available from outside the container with `-p PORT:PORT` if you're not using `--net host`.
@@ -75,12 +75,12 @@ section describe the configuration options in detail.
 ## General configuration
 kafkaproxy requires some general information to start. 
 
-| Name                          | Default value | Destription
-| ----------------------------- | ------------- | -----------
-| `KAFKAPROXY_HOSTNAME`         |               | The hostname of the proxy as seen by the clients.
-| `KAFKAPROXY_BASE_PORT`        |               | The base of the ports to be used by the proxy. Each new required port is created by incrementing on top of the base port.
-| `KAFKAPROXY_BOOTSTRAP_SERVER` |               | The bootstrap endpoint of the kafka cluster. This is usually a load balancer in front of the kafka brokers.
-| `KAFKAPROXY_LOG_LEVEL`        | `INFO`        | The log level of the root logger. This must be a valid log level for [logback](http://logback.qos.ch/manual/configuration.html).
+| Name                           | Default value | Destription
+| ------------------------------ | ------------- | -----------
+| `KAFKAPROXY_HOSTNAME`          |               | The hostname of the proxy as seen by the clients.
+| `KAFKAPROXY_BASE_PORT`         |               | The base of the ports to be used by the proxy. Each new required port is created by incrementing on top of the base port.
+| `KAFKAPROXY_BOOTSTRAP_SERVERS` |               | The comma separated list of initially mapped endpoints. This is usually the list of bootstrap brokers or a load balancer in front of the kafka brokers.
+| `KAFKAPROXY_LOG_LEVEL`         | `INFO`        | The log level of the root logger. This must be a valid log level for [logback](http://logback.qos.ch/manual/configuration.html).
  
 ## Client SSL configuration
 The client SSL configuration determines how the Kafka clients have to connect to the kafkaproxy instances.

--- a/core/src/main/java/com/dajudge/kafkaproxy/BrokerMapper.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/BrokerMapper.java
@@ -21,29 +21,30 @@ import com.dajudge.kafkaproxy.config.BrokerConfigSource;
 import com.dajudge.proxybase.config.Endpoint;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class BrokerMapper {
     private final Map<String, BrokerMapping> allMappings = new HashMap<>();
     private final String proxyHostname;
-    private final Endpoint bootstrapBroker;
+    private final List<Endpoint> bootstrapBrokers;
     private int nextBrokerPort;
 
     public BrokerMapper(final BrokerConfigSource.BrokerConfig brokerConfig) {
         nextBrokerPort = brokerConfig.getProxyBasePort();
         proxyHostname = brokerConfig.getProxyHostname();
-        bootstrapBroker = brokerConfig.getBootstrapBroker();
+        bootstrapBrokers = brokerConfig.getBootstrapBrokers();
     }
 
-    public BrokerMapping getBrokerMapping(final Endpoint brokerEndpoint) {
+    public synchronized BrokerMapping getBrokerMapping(final Endpoint brokerEndpoint) {
         return allMappings.computeIfAbsent(keyOf(brokerEndpoint), key -> new BrokerMapping(
                 brokerEndpoint,
                 new Endpoint(proxyHostname, nextBrokerPort++)
         ));
     }
 
-    public Endpoint getBootstrapBroker() {
-        return bootstrapBroker;
+    public List<Endpoint> getBootstrapBrokers() {
+        return bootstrapBrokers;
     }
 
     private String keyOf(final Endpoint host) {

--- a/core/src/main/java/com/dajudge/kafkaproxy/KafkaProxyApplication.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/KafkaProxyApplication.java
@@ -57,8 +57,8 @@ public class KafkaProxyApplication extends ProxyApplication {
                 proxyChannelFactory
         );
         final KafkaProxyChannelManager proxyChannelManager = new KafkaProxyChannelManager(kafkaProxyChannelFactory);
-        final BrokerMapping boostrapMapping = kafkaProxyChannelFactory.bootstrap(proxyChannelManager);
-        LOG.info("Bootstrap broker mapping: {}", boostrapMapping);
+        kafkaProxyChannelFactory.bootstrap(proxyChannelManager)
+                .forEach(bootstrapMapping -> LOG.info("Bootstrap broker mapping: {}", bootstrapMapping));
         return proxyChannelManager.proxies();
     }
 }

--- a/core/src/main/java/com/dajudge/kafkaproxy/KafkaProxyChannelFactory.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/KafkaProxyChannelFactory.java
@@ -17,10 +17,6 @@
 
 package com.dajudge.kafkaproxy;
 
-import com.dajudge.proxybase.config.Endpoint;
-import com.dajudge.proxybase.FilterFactory;
-import com.dajudge.proxybase.ProxyChannelFactory;
-import com.dajudge.proxybase.ProxyChannel;
 import com.dajudge.kafkaproxy.protocol.KafkaMessageSplitter;
 import com.dajudge.kafkaproxy.protocol.KafkaRequestProcessor;
 import com.dajudge.kafkaproxy.protocol.KafkaRequestStore;
@@ -29,9 +25,16 @@ import com.dajudge.kafkaproxy.protocol.rewrite.CompositeRewriter;
 import com.dajudge.kafkaproxy.protocol.rewrite.FindCoordinatorRewriter;
 import com.dajudge.kafkaproxy.protocol.rewrite.MetadataRewriter;
 import com.dajudge.kafkaproxy.protocol.rewrite.ResponseRewriter;
+import com.dajudge.proxybase.FilterFactory;
+import com.dajudge.proxybase.ProxyChannel;
+import com.dajudge.proxybase.ProxyChannelFactory;
+import com.dajudge.proxybase.config.Endpoint;
 import io.netty.buffer.ByteBuf;
 
+import java.util.List;
+
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 
 public class KafkaProxyChannelFactory {
     private final BrokerMapper brokerMapper;
@@ -65,7 +68,9 @@ public class KafkaProxyChannelFactory {
         );
     }
 
-    public BrokerMapping bootstrap(final KafkaProxyChannelManager manager) {
-        return manager.getByBrokerEndpoint(brokerMapper.getBootstrapBroker());
+    public List<BrokerMapping> bootstrap(final KafkaProxyChannelManager manager) {
+        return brokerMapper.getBootstrapBrokers().stream()
+                .map(manager::getByBrokerEndpoint)
+                .collect(toList());
     }
 }

--- a/core/src/main/java/com/dajudge/kafkaproxy/config/BrokerConfigSource.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/config/BrokerConfigSource.java
@@ -19,7 +19,11 @@ package com.dajudge.kafkaproxy.config;
 
 import com.dajudge.proxybase.config.Endpoint;
 
+import java.util.List;
+import java.util.stream.Stream;
+
 import static java.lang.Integer.parseUnsignedInt;
+import static java.util.stream.Collectors.toList;
 
 public class BrokerConfigSource implements ConfigSource<BrokerConfigSource.BrokerConfig> {
 
@@ -37,25 +41,34 @@ public class BrokerConfigSource implements ConfigSource<BrokerConfigSource.Broke
         );
     }
 
-    private Endpoint getBootstrapBrokers(final Environment environment) {
-        final String bootstrapServer = environment.requiredString("KAFKAPROXY_BOOTSTRAP_SERVER");
-        final String[] bootstrapServerParts = bootstrapServer.split(":");
-        return new Endpoint(bootstrapServerParts[0], parseUnsignedInt(bootstrapServerParts[1]));
+    private List<Endpoint> getBootstrapBrokers(final Environment environment) {
+        final String bootstrapServers = environment.requiredString("KAFKAPROXY_BOOTSTRAP_SERVERS");
+        return Stream.of(bootstrapServers.split(","))
+                .map(bootstrapServer -> {
+                    final String[] bootstrapServerParts = bootstrapServer.split(":");
+                    return new Endpoint(bootstrapServerParts[0], parseUnsignedInt(bootstrapServerParts[1]));
+                })
+                .collect(toList());
+
     }
 
     public static class BrokerConfig {
-        private final Endpoint bootstrapBroker;
+        private final List<Endpoint> bootstrapBrokers;
         private final String proxyHostname;
         private final int proxyBasePort;
 
-        public BrokerConfig(final Endpoint bootstrapBroker, final String proxyHostname, final int proxyBasePort) {
-            this.bootstrapBroker = bootstrapBroker;
+        public BrokerConfig(
+                final List<Endpoint> bootstrapBrokers,
+                final String proxyHostname,
+                final int proxyBasePort
+        ) {
+            this.bootstrapBrokers = bootstrapBrokers;
             this.proxyHostname = proxyHostname;
             this.proxyBasePort = proxyBasePort;
         }
 
-        public Endpoint getBootstrapBroker() {
-            return bootstrapBroker;
+        public List<Endpoint> getBootstrapBrokers() {
+            return bootstrapBrokers;
         }
 
         public String getProxyHostname() {

--- a/core/src/test/java/com/dajudge/kafkaproxy/roundtrip/cluster/KafkaClusterBuilder.java
+++ b/core/src/test/java/com/dajudge/kafkaproxy/roundtrip/cluster/KafkaClusterBuilder.java
@@ -89,7 +89,7 @@ public class KafkaClusterBuilder {
         final ServerSecurity proxySecurity = proxyComm.getServerSecurity("CN=localhost");
         final ClientSslConfig proxyClient = brokerSecurity.newClient("CN=proxy");
         final TestEnvironment env = new TestEnvironment()
-                .withEnv("KAFKAPROXY_BOOTSTRAP_SERVER", kafka.getBootstrapServerList().iterator().next())
+                .withEnv("KAFKAPROXY_BOOTSTRAP_SERVERS", kafka.getBootstrapServerList().iterator().next())
                 .withEnv("KAFKAPROXY_BASE_PORT", valueOf(bootstrapPort))
                 .withEnv("KAFKAPROXY_HOSTNAME", "localhost")
                 .withEnv("KAFKAPROXY_KAFKA_SSL_ENABLED", valueOf("SSL".equals(brokerSecurity.getProtocol())))

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -33,4 +33,4 @@ services:
     environment:
       KAFKAPROXY_HOSTNAME: localhost
       KAFKAPROXY_BASE_PORT: 4000
-      KAFKAPROXY_BOOTSTRAP_SERVER: kafka1:9092
+      KAFKAPROXY_BOOTSTRAP_SERVERS: kafka1:9092


### PR DESCRIPTION
It would be very nice to be able to initially supply a list of bootstrap brokers (as opposed to only one) in order to enable the following use-cases:
* Tolerance for failing bootstrap broker nodes in scenarios without LBs
* Multiple kafka clusters proxied by the same kafkaproxy instance