### PR TITLE
Enable json logging feature for cloud native

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ section describe the configuration options in detail.
 ## General configuration
 kafkaproxy requires some general information to start. 
 
-| Name                           | Default value | Destription
-| ------------------------------ | ------------- | -----------
-| `KAFKAPROXY_HOSTNAME`          |               | The hostname of the proxy as seen by the clients.
-| `KAFKAPROXY_BASE_PORT`         |               | The base of the ports to be used by the proxy. Each new required port is created by incrementing on top of the base port.
-| `KAFKAPROXY_BOOTSTRAP_SERVERS` |               | The comma separated list of initially mapped endpoints. This is usually the list of bootstrap brokers or a load balancer in front of the kafka brokers.
-| `KAFKAPROXY_LOG_LEVEL`         | `INFO`        | The log level of the root logger. This must be a valid log level for [logback](http://logback.qos.ch/manual/configuration.html).
+| Name                               | Default value | Destription
+| ---------------------------------- | ------------- | -----------
+| `KAFKAPROXY_HOSTNAME`              |               | The hostname of the proxy as seen by the clients.
+| `KAFKAPROXY_BASE_PORT`             |               | The base of the ports to be used by the proxy. Each new required port is created by incrementing on top of the base port.
+| `KAFKAPROXY_BOOTSTRAP_SERVERS`     |               | The comma separated list of initially mapped endpoints. This is usually the list of bootstrap brokers or a load balancer in front of the kafka brokers.
+| `KAFKAPROXY_LOG_LEVEL`             | `INFO`        | The log level of the root logger. This must be a valid log level for [logback](http://logback.qos.ch/manual/configuration.html).
+| `KAFKAPROXY_ENABLE_JSON_LOGGING`   | `false`        | Enable/disable json logging feature (only available in quarkus app).
  
 ## Client SSL configuration
 The client SSL configuration determines how the Kafka clients have to connect to the kafkaproxy instances.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-jackson'
     implementation 'io.quarkus:quarkus-kafka-client'
+    implementation 'io.quarkus:quarkus-jsonp'
+    implementation 'io.quarkus:quarkus-logging-json'
     // Used for TLS hostname verification
     implementation 'org.apache.httpcomponents.client5:httpclient5:5.0-beta6'
     // Used for certificate signing

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:INFO}
-%dev.quarkus.log.console.json=false
+quarkus.log.console.json=${KAFKAPROXY_ENABLE_JSON_LOGGING:false}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 quarkus.log.level=${KAFKAPROXY_LOG_LEVEL:INFO}
+%dev.quarkus.log.console.json=false


### PR DESCRIPTION
To integrate better with cloud native environments ELK stack json logging is needed.

- enable quarkus json logging feature
- enable also mandatory quarkus jsonp feature
- enhance application.properties to log without json in devmode