### PR TITLE
Default kafka truststore to built-in cacerts when KAFKAPROXY_KAFKA_SSL_TRUSTSTORE_LOCATION is not set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 ext {
     kafkaClientVersion = "2.8.0"
-    proxyBaseVersion = "0.0.15"
+    proxyBaseVersion = "0.0.16"
     testContainersVersion = "1.15.3"
     junit4Version = "4.11"
     libLogback = 'ch.qos.logback:logback-classic:1.2.3'

--- a/core/src/main/java/com/dajudge/kafkaproxy/config/DownstreamSslConfigSource.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/config/DownstreamSslConfigSource.java
@@ -43,7 +43,7 @@ public class DownstreamSslConfigSource implements ConfigSource<DownstreamSslConf
             return Optional.empty();
         }
         final DownstreamSslConfig downstreamConfig = new DownstreamSslConfig(
-                requiredTrustStoreConfig(environment, KAFKA_SSL_PREFIX),
+                loadTrustStoreConfig(environment, KAFKA_SSL_PREFIX),
                 optionalKeyStoreConfig(environment, KAFKA_SSL_PREFIX),
                 environment.requiredBoolean(ENV_KAFKA_SSL_VERIFY_HOSTNAME, DEFAULT_KAFKA_SSL_VERIFY_HOSTNAME)
         );

--- a/core/src/main/java/com/dajudge/kafkaproxy/config/KeyStoreConfigHelper.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/config/KeyStoreConfigHelper.java
@@ -44,23 +44,11 @@ final class KeyStoreConfigHelper {
         return loadKeyStoreConfig(environment, prefix, false);
     }
 
-    static KeyStoreConfig requiredTrustStoreConfig(final Environment environment, final String prefix) {
-        return loadTrustStoreConfig(environment, prefix, true).orElseThrow(IllegalStateException::new);
-    }
-
-    static Optional<KeyStoreConfig> optionalTrustStoreConfig(final Environment environment, final String prefix) {
-        return loadTrustStoreConfig(environment, prefix, false);
-    }
-
-    private static Optional<KeyStoreConfig> loadTrustStoreConfig(
+    static Optional<KeyStoreConfig> loadTrustStoreConfig(
             final Environment environment,
-            final String prefix,
-            final boolean required
+            final String prefix
     ) {
         final String truststorePrefix = prefix + QUALIFIER_TRUSTSTORE;
-        if (required) {
-            environment.requiredString(truststorePrefix + SUFFIX_LOCATION);
-        }
         return environment.optionalString(truststorePrefix + SUFFIX_LOCATION).map(path -> new KeyStoreConfig(
                 path,
                 environment.optionalString(truststorePrefix + SUFFIX_PASSWORD).orElse("").toCharArray(),

--- a/core/src/main/java/com/dajudge/kafkaproxy/config/UpstreamSslConfigSource.java
+++ b/core/src/main/java/com/dajudge/kafkaproxy/config/UpstreamSslConfigSource.java
@@ -21,7 +21,6 @@ import com.dajudge.proxybase.config.UpstreamSslConfig;
 
 import java.util.Optional;
 
-import static com.dajudge.kafkaproxy.config.KeyStoreConfigHelper.optionalTrustStoreConfig;
 import static com.dajudge.kafkaproxy.config.KeyStoreConfigHelper.requiredKeyStoreConfig;
 
 
@@ -44,7 +43,7 @@ public class UpstreamSslConfigSource implements ConfigSource<UpstreamSslConfig> 
             return Optional.empty();
         }
         return Optional.of(new UpstreamSslConfig(
-                optionalTrustStoreConfig(environment, PREFIX_CLIENT_SSL),
+                KeyStoreConfigHelper.loadTrustStoreConfig(environment, PREFIX_CLIENT_SSL),
                 requiredKeyStoreConfig(environment, PREFIX_CLIENT_SSL),
                 environment.requiredBoolean(PROP_CLIENT_SSL_AUTH_REQUIRED, DEFAULT_CLIENT_AUTH_REQUIRED)
         ));

--- a/core/src/test/java/com/dajudge/kafkaproxy/config/DownstreamSslConfigTest.java
+++ b/core/src/test/java/com/dajudge/kafkaproxy/config/DownstreamSslConfigTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-2021 The kafkaproxy developers (see CONTRIBUTORS)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.dajudge.kafkaproxy.config;
+
+import com.dajudge.kafkaproxy.roundtrip.util.TestEnvironment;
+import com.dajudge.proxybase.config.DownstreamSslConfig;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class DownstreamSslConfigTest {
+    @Test
+    public void downstream_truststore_is_optional() {
+        final Environment env = new TestEnvironment()
+                .withEnv("KAFKAPROXY_KAFKA_SSL_ENABLED", "true");
+        final DownstreamSslConfig config = new ApplicationConfig(env).require(DownstreamSslConfig.class);
+        assertFalse(config.getTrustStore().isPresent());
+    }
+}


### PR DESCRIPTION
Fixes #37